### PR TITLE
feat : 리크루팅 알람 엔티티 개발

### DIFF
--- a/likelion-core/src/main/java/likelion/univ/domain/recruit/Recruit.java
+++ b/likelion-core/src/main/java/likelion/univ/domain/recruit/Recruit.java
@@ -1,0 +1,39 @@
+package likelion.univ.domain.recruit;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Recruit {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recruit_id")
+    private Long id;
+
+    private String name;
+
+    private String email;
+
+    private String phoneNumber;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Recruit(String name, String email, String phoneNumber) {
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+    }
+}


### PR DESCRIPTION
리크루팅 알람 의 경우 수정의 여지가 없다고 판단하여 수정시간(updatedAt) 필드를 추가하지 않았습니다.