### PR TITLE
Feat : 커뮤니티 API 호출시 권한 검사 필터 추가 (GUEST 유저 차단)

### DIFF
--- a/likelion-client/src/main/java/likelion/univ/config/ClientExceptionHandler.java
+++ b/likelion-client/src/main/java/likelion/univ/config/ClientExceptionHandler.java
@@ -1,20 +1,34 @@
 package likelion.univ.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import likelion.univ.exception.AccessDeniedRequestException;
 import likelion.univ.exception.GlobalErrorCode;
 import likelion.univ.exception.base.BaseErrorCode;
 import likelion.univ.exception.base.BaseException;
 import likelion.univ.feign.exception.FeignClientException;
 import likelion.univ.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.net.BindException;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestControllerAdvice
 @Slf4j
@@ -87,4 +101,5 @@ public class ClientExceptionHandler {
         ErrorResponse error = ErrorResponse.of(GlobalErrorCode.SERVER_ERROR);
         return ResponseEntity.status(error.getHttpStatus()).body(error);
     }
+
 }

--- a/likelion-client/src/main/java/likelion/univ/config/CustomAuthenticationEntryPoint.java
+++ b/likelion-client/src/main/java/likelion/univ/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,29 @@
+package likelion.univ.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import likelion.univ.exception.GlobalErrorCode;
+import likelion.univ.response.ErrorResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.LocalDateTime;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        // Error Response Body
+        PrintWriter writer = response.getWriter();
+        ErrorResponse errorDetails = ErrorResponse.of(GlobalErrorCode.ACCESS_DENIED_REQUEST);
+        new ObjectMapper().writeValue(writer, errorDetails);
+        writer.flush();
+    }
+}

--- a/likelion-client/src/main/java/likelion/univ/config/SecurityConfig.java
+++ b/likelion-client/src/main/java/likelion/univ/config/SecurityConfig.java
@@ -40,10 +40,18 @@ public class SecurityConfig {
         http
                 .authorizeRequests()
                 .antMatchers(SwaggerUrlPatterns).permitAll()
-//                .antMatchers("/v1/**").hasRole(ROLE_USER)
-                .antMatchers(HttpMethod.POST, "/v1/project").hasRole("UNIVERSITY_ADMIN")
+
+                // community - 2024.01.29 기준 GUEST 유저는 사용 불능하도록 권한 검사 설정
+//                .antMatchers(HttpMethod.GET, "/v1/community/**").authenticated() // 추후 조회에 대하여는 로그인만 요청할 계획이라 주석으로 냅둠
+                .antMatchers(HttpMethod.GET, "/v1/community/**").hasAnyAuthority("USER", "MANAGER", "UNIVERSITY_ADMIN","SUPER_ADMIN")
+                .antMatchers(HttpMethod.POST, "/v1/community/**").hasAnyAuthority("USER", "MANAGER", "UNIVERSITY_ADMIN","SUPER_ADMIN")
+                .antMatchers(HttpMethod.PUT, "/v1/community/**").hasAnyAuthority("USER", "MANAGER", "UNIVERSITY_ADMIN","SUPER_ADMIN")
+                .antMatchers(HttpMethod.PATCH, "/v1/community/**").hasAnyAuthority("USER", "MANAGER", "UNIVERSITY_ADMIN","SUPER_ADMIN")
+                .antMatchers(HttpMethod.DELETE, "/v1/community/**").hasAnyAuthority("USER", "MANAGER", "UNIVERSITY_ADMIN","SUPER_ADMIN")
+
 //                .anyRequest().authenticated();
                 .anyRequest().permitAll(); //임시
+
         return http.build();
     }
 }

--- a/likelion-client/src/main/java/likelion/univ/config/SecurityConfig.java
+++ b/likelion-client/src/main/java/likelion/univ/config/SecurityConfig.java
@@ -22,6 +22,8 @@ import static likelion.univ.constant.StaticValue.SwaggerUrlPatterns;
 public class SecurityConfig {
     private final FilterProcessor filterProcessor;
     private final AccessProcessor accessProcessor;
+    private final CustomAuthenticationEntryPoint entryPoint;
+
 
     @Bean
     public BCryptPasswordEncoder encoder() {
@@ -35,8 +37,9 @@ public class SecurityConfig {
         http.formLogin().disable();
         http.sessionManagement( ).sessionCreationPolicy(SessionCreationPolicy.STATELESS); // JWT이용으로 세션 이용 x
         filterProcessor.common(http);
+        http.exceptionHandling().authenticationEntryPoint(entryPoint); // 로그인 x 유저에 대한 Custom ErrorResponse 제공
         http.authorizeRequests().expressionHandler(accessProcessor.expressionHandler());
-
+        
         http
                 .authorizeRequests()
                 .antMatchers(SwaggerUrlPatterns).permitAll()
@@ -48,6 +51,7 @@ public class SecurityConfig {
                 .antMatchers(HttpMethod.PUT, "/v1/community/**").hasAnyAuthority("USER", "MANAGER", "UNIVERSITY_ADMIN","SUPER_ADMIN")
                 .antMatchers(HttpMethod.PATCH, "/v1/community/**").hasAnyAuthority("USER", "MANAGER", "UNIVERSITY_ADMIN","SUPER_ADMIN")
                 .antMatchers(HttpMethod.DELETE, "/v1/community/**").hasAnyAuthority("USER", "MANAGER", "UNIVERSITY_ADMIN","SUPER_ADMIN")
+
 
 //                .anyRequest().authenticated();
                 .anyRequest().permitAll(); //임시

--- a/likelion-core/src/main/resources/application-core.yml
+++ b/likelion-core/src/main/resources/application-core.yml
@@ -86,30 +86,4 @@ logging:
     org.springframework.orm.jpa: INFO
     org.springframework.transaction: INFO
 
---- ## test 환경 설정 for local
-#spring:
-#  config:
-#    activate:
-#      on-profile: test
-#  datasource:
-#    driver-class-name: org.h2.Driver
-#    url: jdbc:h2:tcp://localhost/~/likelionuniv
-#    username: sa
-#    password:
-#  jpa:
-#    show-sql: true
-#    open-in-view: false
-#    hibernate:
-#      ddl-auto: none
-#    properties:
-#      hibernate:
-#        default_batch_fetch_size: 1000
-#        format_sql: true
-#  logging:
-#  level:
-#    org.springframework.orm.jpa: DEBUG
-#    org.springframework.transaction: DEBUG
-#  pattern:
-#    console: "%d{yyyy-MM-dd HH:mm:ss} - %msg%n"
-
 

--- a/likelion-security/src/main/java/likelion/univ/security/AccessProcessor.java
+++ b/likelion-security/src/main/java/likelion/univ/security/AccessProcessor.java
@@ -1,8 +1,15 @@
 package likelion.univ.security;
 
 import likelion.univ.annotation.Processor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 @Processor
 public class AccessProcessor {
@@ -18,4 +25,5 @@ public class AccessProcessor {
         expressionHandler.setRoleHierarchy(roleHierarchy());
         return expressionHandler;
     }
+
 }

--- a/likelion-security/src/main/java/likelion/univ/security/AccessProcessor.java
+++ b/likelion-security/src/main/java/likelion/univ/security/AccessProcessor.java
@@ -1,15 +1,8 @@
 package likelion.univ.security;
 
 import likelion.univ.annotation.Processor;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
-import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 @Processor
 public class AccessProcessor {


### PR DESCRIPTION
2024.01.29. 미팅 내용에 따라 요구사항 백엔드 구현 완료했습니다.

작업내용
- [x] security config 파일 내 filterchain 상에서 community api 호출시 유저 권한 체크 추가
- [x] 로그인 x 유저가 커뮤니티 서비스 접근시 제공되는 error response를 커스텀으로 제공하게끔 customentrypoint 추가