### PR TITLE
feat : 어드민 해커톤참가신청 내역 조회 api 추가

### DIFF
--- a/likelion-admin/src/main/java/likelion/univ/config/SecurityConfig.java
+++ b/likelion-admin/src/main/java/likelion/univ/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
                 .permitAll()
                 .antMatchers("/v1/univAdmin/**").hasRole("MANAGER")
                 .antMatchers("/v1/headquaters/**").hasRole("SUPER_ADMIN")
+                .antMatchers("/v1/hackathons/**").hasRole("SUPER_ADMIN")
 //                .antMatchers("/v1/**").hasRole(ROLE_USER)
 //                .anyRequest().authenticated();
                 .anyRequest().permitAll(); //임시

--- a/likelion-admin/src/main/java/likelion/univ/hackathon/controller/HackathonController.java
+++ b/likelion-admin/src/main/java/likelion/univ/hackathon/controller/HackathonController.java
@@ -1,0 +1,36 @@
+package likelion.univ.hackathon.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
+import likelion.univ.common.response.PageResponse;
+import likelion.univ.domain.hackathon.entity.HackathonForm;
+import likelion.univ.domain.hackathon.response.HackathonFindResponse;
+import likelion.univ.domain.hackathon.service.HackathonService;
+import likelion.univ.hackathon.dto.request.HackathonFormSearchRequest;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.api.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/hackathons")
+@Tag(name = "해커톤", description = "어드민 해커톤 API")
+public class HackathonController {
+
+    private final HackathonService hackathonService;
+
+    @Operation(summary = "해커톤 신청 조회")
+    @GetMapping
+    public PageResponse<HackathonFindResponse> searchHackathons(
+            @ParameterObject @Valid HackathonFormSearchRequest request,
+            @ParameterObject Pageable pageable
+    ) {
+        Page<HackathonForm> result = hackathonService.search(request.toCondition(), pageable);
+        return PageResponse.of(result.map(HackathonFindResponse::from));
+    }
+}

--- a/likelion-admin/src/main/java/likelion/univ/hackathon/dto/request/HackathonFormSearchRequest.java
+++ b/likelion-admin/src/main/java/likelion/univ/hackathon/dto/request/HackathonFormSearchRequest.java
@@ -1,0 +1,26 @@
+package likelion.univ.hackathon.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
+import likelion.univ.domain.hackathon.repository.condition.HackathonFormSearchCondition;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// 추후 레코드로 변경하기
+@Getter
+@AllArgsConstructor
+public class HackathonFormSearchRequest {
+    @Schema(description = "검색 키워드", example = "김멋사")
+    String keyword;
+
+    @NotNull(message = "엑셀 다운로드 여부가 비었습니다.")
+    @Schema(description = "엑셀 다운로드 여부", example = "true")
+    Boolean isExcelData;
+
+    public HackathonFormSearchCondition toCondition() {
+        return new HackathonFormSearchCondition(
+                keyword,
+                isExcelData
+        );
+    }
+}

--- a/likelion-core/src/main/java/likelion/univ/domain/hackathon/repository/HackathonFormCustomRepository.java
+++ b/likelion-core/src/main/java/likelion/univ/domain/hackathon/repository/HackathonFormCustomRepository.java
@@ -1,0 +1,11 @@
+package likelion.univ.domain.hackathon.repository;
+
+import likelion.univ.domain.hackathon.entity.HackathonForm;
+import likelion.univ.domain.hackathon.repository.condition.HackathonFormSearchCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface HackathonFormCustomRepository {
+
+    Page<HackathonForm> search(HackathonFormSearchCondition condition, Pageable pageable);
+}

--- a/likelion-core/src/main/java/likelion/univ/domain/hackathon/repository/HackathonFormRepository.java
+++ b/likelion-core/src/main/java/likelion/univ/domain/hackathon/repository/HackathonFormRepository.java
@@ -4,7 +4,7 @@ import likelion.univ.domain.hackathon.entity.HackathonForm;
 import likelion.univ.domain.hackathon.exception.HackathonFormNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface HackathonFormRepository extends JpaRepository<HackathonForm, Long> {
+public interface HackathonFormRepository extends JpaRepository<HackathonForm, Long>, HackathonFormCustomRepository {
 
     default HackathonForm getById(Long id) {
         return findById(id).orElseThrow(HackathonFormNotFoundException::new);

--- a/likelion-core/src/main/java/likelion/univ/domain/hackathon/repository/condition/HackathonFormSearchCondition.java
+++ b/likelion-core/src/main/java/likelion/univ/domain/hackathon/repository/condition/HackathonFormSearchCondition.java
@@ -1,0 +1,7 @@
+package likelion.univ.domain.hackathon.repository.condition;
+
+public record HackathonFormSearchCondition(
+        String keyword,
+        boolean isExcelData
+) {
+}

--- a/likelion-core/src/main/java/likelion/univ/domain/hackathon/repository/impl/HackathonFormCustomRepositoryImpl.java
+++ b/likelion-core/src/main/java/likelion/univ/domain/hackathon/repository/impl/HackathonFormCustomRepositoryImpl.java
@@ -1,0 +1,64 @@
+package likelion.univ.domain.hackathon.repository.impl;
+
+import static likelion.univ.domain.hackathon.entity.QHackathonForm.hackathonForm;
+
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import likelion.univ.domain.hackathon.entity.HackathonForm;
+import likelion.univ.domain.hackathon.repository.HackathonFormCustomRepository;
+import likelion.univ.domain.hackathon.repository.condition.HackathonFormSearchCondition;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@RequiredArgsConstructor
+public class HackathonFormCustomRepositoryImpl implements HackathonFormCustomRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<HackathonForm> search(HackathonFormSearchCondition condition, Pageable pageable) {
+        List<Long> ids = getCoveringIndex(keywordContains(condition.keyword()));
+
+        List<HackathonForm> result = queryFactory.select(hackathonForm)
+                .from(hackathonForm)
+                .leftJoin(hackathonForm.university)
+                .fetchJoin()
+                .where(hackathonForm.id.in(ids))
+                .orderBy(hackathonForm.createdDate.desc())
+                .offset(condition.isExcelData() ? 0 : pageable.getOffset())
+                .limit(
+                        condition.isExcelData()
+                                ? ids.size() + 1
+                                : pageable.getPageSize())
+                .fetch();
+
+        return condition.isExcelData()
+                ? PageableExecutionUtils.getPage(
+                result, PageRequest.of(0, ids.size() + 1), ids::size)
+                : PageableExecutionUtils.getPage(result, pageable, ids::size);
+    }
+
+    /**
+     * Page 기반 페이지네이션을 위한 커버링인덱스 구하는 함수
+     *
+     * @param predicate 탐색 조건
+     * @return 커버링 인덱스
+     */
+    private List<Long> getCoveringIndex(Predicate predicate) {
+        return queryFactory.select(hackathonForm.id).from(hackathonForm).where(predicate).fetch();
+    }
+
+    /**
+     * 검색어
+     */
+    private BooleanExpression keywordContains(String keyword) {
+        return keyword != null
+                ? hackathonForm.name.contains(keyword)
+                .or(hackathonForm.university.name.contains(keyword))
+                : null;
+    }
+}

--- a/likelion-core/src/main/java/likelion/univ/domain/hackathon/service/HackathonService.java
+++ b/likelion-core/src/main/java/likelion/univ/domain/hackathon/service/HackathonService.java
@@ -2,6 +2,7 @@ package likelion.univ.domain.hackathon.service;
 
 import likelion.univ.domain.hackathon.entity.HackathonForm;
 import likelion.univ.domain.hackathon.repository.HackathonFormRepository;
+import likelion.univ.domain.hackathon.repository.condition.HackathonFormSearchCondition;
 import likelion.univ.domain.hackathon.response.HackathonFindResponse;
 import likelion.univ.domain.hackathon.service.command.HackathonApplyCommand;
 import likelion.univ.domain.hackathon.service.command.HackathonModifyCommand;
@@ -10,6 +11,8 @@ import likelion.univ.domain.university.repository.UniversityRepository;
 import likelion.univ.domain.user.entity.User;
 import likelion.univ.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,5 +51,10 @@ public class HackathonService {
                 command.offlineParticipation(),
                 command.reasonForNotOffline()
         );
+    }
+
+    public Page<HackathonForm> search(HackathonFormSearchCondition condition, Pageable pageable) {
+        Page<HackathonForm> result = hackathonFormRepository.search(condition, pageable);
+        return result;
     }
 }


### PR DESCRIPTION
어드민용 해커톤 참가신청 조회 Api 추가했습니다!

엑셀데이터의 경우 페이지네이션제외하고 전체데이터 조회하도록 구현했습니다.

request를 record로 구현하려 햇으나, 현재 저희 스웨거 springdocs버전이 낮아서 
record에 parameterObject어노테이션이 붙인건 지원안해주더라구요..

제가 추후 spring버전 올리면서 springdocs버전도 올리면서 저 request를 class->record로 변환하겠습니다!!


- close #122 